### PR TITLE
fix minor newcomer-blockers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ workbench/
 .DS_Store
 *.pyc
 .idea/
+log/
+

--- a/ddp/__main__.py
+++ b/ddp/__main__.py
@@ -2,11 +2,7 @@
 
 Usage:
 
-python ddp [-w] [-c CAM_NUM] [-u URL] [-i IMAGE_FILE] PIPELINE
-
-positional arguments:
-
-    PIPELINE: The pipeline to run.
+python ddp [-w] [-c CAM_NUM] [-u URL] [-i IMAGE_FILE] [--pipeline PIPELINE]
 
 optional arguments:
 
@@ -27,7 +23,7 @@ optional arguments:
 
 Examples:
 
-    python ddp extract_paper
+    python ddp --pipeline extract_paper
 
 
 Notes:
@@ -85,6 +81,7 @@ def main():
     frame = None
     capture = None
     pipeline_name = options.pipeline
+
     pipeline = importlib.import_module("pipeline." + pipeline_name)
     assert hasattr(pipeline, Settings.METHOD_NAME_TO_RUN),\
         "module has to have " + Settings.METHOD_NAME_TO_RUN + " method"
@@ -131,8 +128,5 @@ def main():
 
     close()
 
-
-
 if __name__ == "__main__":
     main()
-

--- a/ddp/core/vision.py
+++ b/ddp/core/vision.py
@@ -110,7 +110,7 @@ def binarize_ink_IMPROVED(grey):
 
 
 def white_balance(inimg, randomPoolSize = 100, selectionPoolSize = 20):
-    img = inimg.copy()
+    img = inimg.astype(float, casting='unsafe')
     height, width, colors = img.shape  # y, x, color
     randomPixels = map(
         lambda id: img[
@@ -143,7 +143,7 @@ def white_balance(inimg, randomPoolSize = 100, selectionPoolSize = 20):
     img[:, :, 0] -= dg
     img[:, :, 1] -= db
     img[:, :, 2] -= dr
-    return img
+    return img.astype('uint8')
 
 
 # img is a binary image where ink is white, paper is black. This

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Python libraries to install:
 
 * cv2
 * numpy
+* scipy
 * scikit-image
 * networkx
 * cairosvg

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ For camera server:
 
 Run a pipeline with, e.g.
 
-    python ddp extract_paper
+    python ddp --pipeline extract_paper
 
 Check out `ddp/__main__.py` for command line options.
 


### PR DESCRIPTION
You folks at CDG Labs seem to have vowed to implement my todo list :) First the Prolog visualizer, then Ohm, then Apparatus and Vogo, then this!

I don't know if I have the full picture about this project, but since a while I've been meaning to write some data pipelines in which to feed my paper notes for various purposes. For example, designing Flexbox layouts with color pencils and paper would be a big time-saver! Also, I tend to design my programs by writing data pipelines as graphs - why should I write code? In the long run, I think the biggest time-savings I could get from a paper UI would be relative to personal organization rather than programming, but I have no design about anything yet. I'm not planning to work on this before long, but I thought you might like to know there's a NEED for this thing :)

This PR fixes a runtime exception when running `extract_paper`. If the error doesn't occur on your machine it might be because of [the version of NumPy you're using](http://stackoverflow.com/questions/14269164/why-do-casting-rules-differ-between-computers-in-python#14270230) (this thread being quite old, it would surprise me but who knows).

I like where you folks are headed, keep going!
